### PR TITLE
PyInstaller backend, dynamic port and CI build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,26 +19,28 @@ jobs:
         with:
           node-version: '18'
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies & PyInstaller
+        run: |
+          pip install -r Server/requirements.txt
+          pip install pyinstaller
+
+      - name: Build backend binary
+        run: pyinstaller sAIve-backend.spec --distpath dist
+        working-directory: Server
+
       - name: Install Node.js dependencies
         run: npm install
         working-directory: sAIve
-
-      - name: Set up portable Python
-        run: |
-          curl -L -o python.tar.gz https://github.com/astral-sh/python-build-standalone/releases/download/20250610/cpython-3.11.13+20250610-x86_64-apple-darwin-install_only.tar.gz
-          tar -xzf python.tar.gz -C Server/
-          mv Server/python Server/venv
-
-      - name: Install Python dependencies
-        run: |
-          Server/venv/bin/python3 -m pip install --upgrade pip
-          Server/venv/bin/python3 -m pip install -r Server/requirements.txt
 
       - name: Build macOS application
         run: npm run electron:build
         working-directory: sAIve
         env:
-          # This is important for macOS notarization if you set it up
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -61,21 +63,23 @@ jobs:
         with:
           node-version: '18'
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies & PyInstaller
+        run: |
+          pip install -r Server/requirements.txt
+          pip install pyinstaller
+
+      - name: Build backend binary
+        run: pyinstaller sAIve-backend.spec --distpath dist
+        working-directory: Server
+
       - name: Install Node.js dependencies
         run: npm install
         working-directory: sAIve
-
-      - name: Set up portable Python
-        shell: powershell
-        run: |
-          Invoke-WebRequest -Uri https://github.com/astral-sh/python-build-standalone/releases/download/20250610/cpython-3.11.13+20250610-x86_64-pc-windows-msvc-install_only.tar.gz -OutFile python.tar.gz
-          tar -xzf python.tar.gz -C Server/
-          Move-Item -Path Server/python -Destination Server/venv
-
-      - name: Install Python dependencies
-        run: |
-          Server/venv/python.exe -m pip install --upgrade pip
-          Server/venv/python.exe -m pip install -r Server/requirements.txt
 
       - name: Build Windows application
         run: npm run electron:build

--- a/Server/database.py
+++ b/Server/database.py
@@ -1,7 +1,13 @@
 import sqlite3
+import sys
 from pathlib import Path
 
-DATABASE_PATH = Path(__file__).parent.resolve() / "database.db"
+if getattr(sys, 'frozen', False):
+    # Running as a PyInstaller bundle — put DB next to the executable
+    DATABASE_PATH = Path(sys.executable).parent / "database.db"
+else:
+    # Running in development
+    DATABASE_PATH = Path(__file__).parent.resolve() / "database.db"
 
 def create_connection():
     conn = sqlite3.connect(DATABASE_PATH)

--- a/Server/main.py
+++ b/Server/main.py
@@ -432,3 +432,18 @@ def organize_assets(user_id: int, transactions: list[models.TransactionCreate]):
         )
 
         crud.create_user_asset(asset)
+
+if __name__ == "__main__":
+    import uvicorn
+    import socket
+
+    # Let the OS assign a free port
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+
+    # Signal the port to Electron (must be flushed immediately)
+    print(f"PORT:{port}", flush=True)
+
+    uvicorn.run(app, host="127.0.0.1", port=port, log_level="info")

--- a/Server/sAIve-backend.spec
+++ b/Server/sAIve-backend.spec
@@ -1,0 +1,49 @@
+# -*- mode: python ; coding: utf-8 -*-
+# PyInstaller spec for sAIve backend
+
+a = Analysis(
+    ['main.py'],
+    pathex=[],
+    binaries=[],
+    datas=[],
+    hiddenimports=[
+        'uvicorn.logging',
+        'uvicorn.loops',
+        'uvicorn.loops.auto',
+        'uvicorn.protocols',
+        'uvicorn.protocols.http',
+        'uvicorn.protocols.http.auto',
+        'uvicorn.protocols.websockets',
+        'uvicorn.protocols.websockets.auto',
+        'uvicorn.lifespan',
+        'uvicorn.lifespan.on',
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='sAIve-backend',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/sAIve/dist-electron/preload.js
+++ b/sAIve/dist-electron/preload.js
@@ -1,8 +1,9 @@
 const { contextBridge, ipcRenderer } = require("electron");
 contextBridge.exposeInMainWorld("electronAPI", {
-  // Example: expose a function to send a message to the main process
+  // Get the dynamically assigned backend port
+  getBackendPort: () => ipcRenderer.invoke("get-backend-port"),
+  // Generic IPC helpers
   sendMessage: (channel, data) => ipcRenderer.send(channel, data),
-  // Example: expose a function to receive messages from the main process
   onMessage: (channel, func) => {
     ipcRenderer.on(channel, (event, ...args) => func(...args));
   }

--- a/sAIve/package.json
+++ b/sAIve/package.json
@@ -1,7 +1,7 @@
 {
   "name": "saive",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "An AI-powered budgeting application.",
   "author": "DIIZZY",
   "type": "module",
@@ -85,10 +85,10 @@
     ],
     "extraResources": [
       {
-        "from": "../Server",
-        "to": "app/Server",
+        "from": "../Server/dist/",
+        "to": "backend",
         "filter": [
-          "**/*"
+          "sAIve-backend*"
         ]
       }
     ],

--- a/sAIve/public/preload.js
+++ b/sAIve/public/preload.js
@@ -1,11 +1,13 @@
-// electron/preload.js (or public/preload.js)
+// public/preload.js
 const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('electronAPI', {
-  // Example: expose a function to send a message to the main process
+  // Get the dynamically assigned backend port
+  getBackendPort: () => ipcRenderer.invoke('get-backend-port'),
+
+  // Generic IPC helpers
   sendMessage: (channel, data) => ipcRenderer.send(channel, data),
-  // Example: expose a function to receive messages from the main process
   onMessage: (channel, func) => {
     ipcRenderer.on(channel, (event, ...args) => func(...args));
-  }
+  },
 });

--- a/sAIve/src/lib/api.ts
+++ b/sAIve/src/lib/api.ts
@@ -1,10 +1,24 @@
 import axios from 'axios';
 
-const API_BASE_URL = 'http://localhost:8000';
-
+// Default to localhost:8000 — will be updated at startup via configureApi()
 const api = axios.create({
-  baseURL: API_BASE_URL,
-  // You can set other default configs here
+  baseURL: 'http://localhost:8000',
 });
+
+/**
+ * Called once at app startup to set the backend port.
+ * In Electron, this reads the dynamic port from the main process.
+ * Falls back to 8000 if not running in Electron.
+ */
+export async function configureApi() {
+  try {
+    const port = await (window as any).electronAPI?.getBackendPort();
+    if (port) {
+      api.defaults.baseURL = `http://localhost:${port}`;
+    }
+  } catch {
+    // Not in Electron or IPC unavailable — keep default
+  }
+}
 
 export default api;

--- a/sAIve/src/main.tsx
+++ b/sAIve/src/main.tsx
@@ -6,19 +6,23 @@ import { ThemeProvider } from "@/components/ThemeProvider";
 import { SettingsProvider } from "@/context/SettingsContext";
 import { AiProvider } from "@/context/AiContext";
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { configureApi } from '@/lib/api';
 
 const queryClient = new QueryClient();
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <ThemeProvider defaultTheme="system" storageKey="vite-ui-theme">
-      <SettingsProvider>
-        <QueryClientProvider client={queryClient}>
-          <AiProvider>
-            <AppShell />
-          </AiProvider>
-        </QueryClientProvider>
-      </SettingsProvider>
-    </ThemeProvider>
-  </StrictMode>,
-);
+// Configure the backend port before rendering
+configureApi().then(() => {
+  createRoot(document.getElementById('root')!).render(
+    <StrictMode>
+      <ThemeProvider defaultTheme="system" storageKey="vite-ui-theme">
+        <SettingsProvider>
+          <QueryClientProvider client={queryClient}>
+            <AiProvider>
+              <AppShell />
+            </AiProvider>
+          </QueryClientProvider>
+        </SettingsProvider>
+      </ThemeProvider>
+    </StrictMode>,
+  );
+});


### PR DESCRIPTION
Add PyInstaller packaging and dynamic backend port wiring.

- CI: install Python, pip deps and pyinstaller; build backend binary in Server via a new sAIve-backend.spec.
- Server: main.py now binds to an ephemeral free port, prints PORT:<port> and starts uvicorn; database.py uses a DB path next to the executable when frozen (PyInstaller) and falls back to source path in dev.
- Electron: start packaged backend binary (or python in dev), parse PORT:<port> from stdout, expose ipc handler get-backend-port, use the discovered port for health checks and faster polling, and add startup error handling/timeouts.
- Preload/renderer: expose getBackendPort to renderer; add configureApi() to set axios baseURL from the dynamic port and call it before rendering in main.tsx.
- package.json: bump version to 0.3.0 and update extraResources to include the built backend binary under backend.

These changes enable building a standalone backend executable, having the backend choose a free port at runtime, and letting the Electron frontend discover and use that port reliably.